### PR TITLE
[FIX] Disabling multicurrency in AFR

### DIFF
--- a/account_financial_report/wizard/wizard.py
+++ b/account_financial_report/wizard/wizard.py
@@ -54,7 +54,8 @@ class wizard_report(osv.osv_memory):
             ('five', 'Initial | Debit | Credit | Period | YTD'),
             ('qtr', "4 QTR's | YTD"),
             ('thirteen', '12 Months | YTD'),
-            ('currency', 'End. Balance Currency')], 'Columns', required=True),
+            # ('currency', 'End. Balance Currency'),
+            ], 'Columns', required=True),
         'display_account': fields.selection(
             [('all', 'All Accounts'), ('bal', 'With Balance'),
              ('mov', 'With movements'),


### PR DESCRIPTION
As multicurrency feature is not yet mature, and bank_statement
module is not working to comply with Exchange rate difference set
in cero in amount currency, this feature will not be activated
