### PR TITLE
Revert "[IMP][account_financial_report] Allow calculate initial balance set the value periods_special in context"

### DIFF
--- a/account_financial_report/report/parser.py
+++ b/account_financial_report/report/parser.py
@@ -1078,7 +1078,6 @@ class AccountBalance(report_sxw.rml_parse):
         def zfunction(nval):
             return abs(nval) < 0.005 and 0.0 or nval
         self.context = dict(self.context)
-        self.context['periods_special'] = True
         account_ids = []
         self.context['state'] = form['target_move'] or 'posted'
 


### PR DESCRIPTION
Reverts Vauxoo/odoo-afr#30

This change needs to be reverted because the follow [Odoo commit](https://github.com/Vauxoo/odoo/commit/7b7f3fa76a822f05283e36b40bdbc58793f84570) can caused this:
1.- The balance sheet report only are going to consider initial periods and not balance.
2.- If the new context parameter `periods_special` is set on this module to calculate initial balance only will be considering to the initial balance the amount of the opening period and not opening period + balance on the period, the current behaviour of Odoo is considering only special periods or not special periods for a balance of account. 
